### PR TITLE
Introduce own field for Hytera HDAP reliable message bit

### DIFF
--- a/okdmr/kaitai/hytera/hytera_dmr_application_protocol.ksy
+++ b/okdmr/kaitai/hytera/hytera_dmr_application_protocol.ksy
@@ -22,13 +22,13 @@ types:
     seq:
       - id: data
         size-eos: true
-instances:
-  is_reliable_message:
-    value: (message_header.to_i & 0b10000000) >> 7
-    doc: first bit of message_header indicates if the message is reliable
+
 seq:
+  - id: is_reliable_message
+    type: b1
+    doc: first bit of message_header indicates if the message is reliable
   - id: message_header
-    type: u1
+    type: b7
     enum: message_header_types
   - id: data
     doc: |

--- a/okdmr/kaitai/hytera/hytera_dmr_application_protocol.py
+++ b/okdmr/kaitai/hytera/hytera_dmr_application_protocol.py
@@ -6,22 +6,18 @@ from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 from enum import Enum
 
 
-if parse_version(kaitaistruct.__version__) < parse_version("0.9"):
-    raise Exception(
-        "Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s"
-        % (kaitaistruct.__version__)
-    )
+if parse_version(kaitaistruct.__version__) < parse_version('0.9'):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
 
+from okdmr.kaitai.hytera import radio_registration_service
 from okdmr.kaitai.hytera import radio_control_protocol
+from okdmr.kaitai.hytera import location_protocol
+from okdmr.kaitai.hytera import text_message_protocol
+from okdmr.kaitai.hytera import data_transmit_protocol
 from okdmr.kaitai.hytera import data_delivery_states
 from okdmr.kaitai.hytera import telemetry_protocol
-from okdmr.kaitai.hytera import text_message_protocol
-from okdmr.kaitai.hytera import location_protocol
-from okdmr.kaitai.hytera import radio_registration_service
-from okdmr.kaitai.hytera import data_transmit_protocol
-
-
 class HyteraDmrApplicationProtocol(KaitaiStruct):
+
     class MessageHeaderTypes(Enum):
         radio_control_protocol = 2
         location_protocol = 8
@@ -30,7 +26,6 @@ class HyteraDmrApplicationProtocol(KaitaiStruct):
         telemetry_protocol = 18
         data_transmit_protocol = 19
         data_delivery_states = 20
-
     def __init__(self, _io, _parent=None, _root=None):
         self._io = _io
         self._parent = _parent
@@ -38,40 +33,28 @@ class HyteraDmrApplicationProtocol(KaitaiStruct):
         self._read()
 
     def _read(self):
-        self.message_header = KaitaiStream.resolve_enum(
-            HyteraDmrApplicationProtocol.MessageHeaderTypes, self._io.read_u1()
-        )
+        self.is_reliable_message = self._io.read_bits_int_be(1) != 0
+        self.message_header = KaitaiStream.resolve_enum(HyteraDmrApplicationProtocol.MessageHeaderTypes, self._io.read_bits_int_be(7))
+        self._io.align_to_byte()
         _on = self.message_header
         if _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.radio_registration:
             self.data = radio_registration_service.RadioRegistrationService(self._io)
         elif _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.telemetry_protocol:
             self.data = telemetry_protocol.TelemetryProtocol(self._io)
-        elif (
-            _on
-            == HyteraDmrApplicationProtocol.MessageHeaderTypes.radio_control_protocol
-        ):
+        elif _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.radio_control_protocol:
             self.data = radio_control_protocol.RadioControlProtocol(self._io)
-        elif (
-            _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.text_message_protocol
-        ):
+        elif _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.text_message_protocol:
             self.data = text_message_protocol.TextMessageProtocol(self._io)
-        elif (
-            _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.data_delivery_states
-        ):
+        elif _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.data_delivery_states:
             self.data = data_delivery_states.DataDeliveryStates(self._io)
         elif _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.location_protocol:
             self.data = location_protocol.LocationProtocol(self._io)
-        elif (
-            _on
-            == HyteraDmrApplicationProtocol.MessageHeaderTypes.data_transmit_protocol
-        ):
+        elif _on == HyteraDmrApplicationProtocol.MessageHeaderTypes.data_transmit_protocol:
             self.data = data_transmit_protocol.DataTransmitProtocol(self._io)
         self.checksum = self._io.read_u1()
         self.message_footer = self._io.read_bytes(1)
         if not self.message_footer == b"\x03":
-            raise kaitaistruct.ValidationNotEqualError(
-                b"\x03", self.message_footer, self._io, u"/seq/3"
-            )
+            raise kaitaistruct.ValidationNotEqualError(b"\x03", self.message_footer, self._io, u"/seq/4")
 
     class UndefinedProtocol(KaitaiStruct):
         def __init__(self, _io, _parent=None, _root=None):
@@ -83,19 +66,5 @@ class HyteraDmrApplicationProtocol(KaitaiStruct):
         def _read(self):
             self.data = self._io.read_bytes_full()
 
-    @property
-    def is_reliable_message(self):
-        """first bit of message_header indicates if the message is reliable."""
-        if hasattr(self, "_m_is_reliable_message"):
-            return (
-                self._m_is_reliable_message
-                if hasattr(self, "_m_is_reliable_message")
-                else None
-            )
 
-        self._m_is_reliable_message = (self.message_header.value & 128) >> 7
-        return (
-            self._m_is_reliable_message
-            if hasattr(self, "_m_is_reliable_message")
-            else None
-        )
+


### PR DESCRIPTION
The reliable message bit is its own field. 

The nextfield is an bitsized integer, as otherwise the ENUM values would not match when
the reliable message bit is set.

