### PR TITLE
Introduce testing for Hytera Location Protocol

### DIFF
--- a/okdmr/kaitai/hytera/gpsdata.ksy
+++ b/okdmr/kaitai/hytera/gpsdata.ksy
@@ -1,5 +1,6 @@
 meta:
   id: gpsdata
+
 seq:
   - id: gps_status
     size: 1
@@ -28,3 +29,7 @@ seq:
   - id: direction
     size: 3
     doc: azimuth(0-359), 0=north, increase is clockwise
+
+instances:
+    gps_available:
+        value: gps_status.to_s('ASCII') == 'A'

--- a/okdmr/kaitai/hytera/gpsdata.py
+++ b/okdmr/kaitai/hytera/gpsdata.py
@@ -5,12 +5,8 @@ import kaitaistruct
 from kaitaistruct import KaitaiStruct, KaitaiStream, BytesIO
 
 
-if parse_version(kaitaistruct.__version__) < parse_version("0.9"):
-    raise Exception(
-        "Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s"
-        % (kaitaistruct.__version__)
-    )
-
+if parse_version(kaitaistruct.__version__) < parse_version('0.9'):
+    raise Exception("Incompatible Kaitai Struct Python API: 0.9 or later is required, but you have %s" % (kaitaistruct.__version__))
 
 class Gpsdata(KaitaiStruct):
     def __init__(self, _io, _parent=None, _root=None):
@@ -29,3 +25,13 @@ class Gpsdata(KaitaiStruct):
         self.longitude = self._io.read_bytes(10)
         self.speed = self._io.read_bytes(3)
         self.direction = self._io.read_bytes(3)
+
+    @property
+    def gps_available(self):
+        if hasattr(self, '_m_gps_available'):
+            return self._m_gps_available if hasattr(self, '_m_gps_available') else None
+
+        self._m_gps_available = (self.gps_status).decode(u"ASCII") == u"A"
+        return self._m_gps_available if hasattr(self, '_m_gps_available') else None
+
+

--- a/okdmr/tests/kaitai/hytera/test_location_protocol.py
+++ b/okdmr/tests/kaitai/hytera/test_location_protocol.py
@@ -1,24 +1,57 @@
+import unittest
+
 from typing import List
 
 from okdmr.kaitai.hytera.location_protocol import LocationProtocol
 from okdmr.tests.kaitai.tests_utils import prettyprint
 
 
-def test_lp():
-    hexmessages: List[str] = [
-        # location protocol
-        "a0030034000000000a2338630000413131323534303237303932314e353030332e383734364530313432362e35313932302e32323533ff1cae03",
-        "A0010009200000030A03640E01E503",
-        "a0020032200000030a03640e0000413136323235313331313031384e343733362e363937354530303733392e32363830302e303030358803",
-        "a0010009200000010a03640e01e703",
-        "a0020032200000010a03640e0000413136323232333331313031384e343733362e363937374530303733392e32363830302e303030358903",
-        "a0010009200000020a03640e01e603",
-        # Condition report, no data
-        "d0010039200000020a03640e04000003e830303030303030303030303030303030303030303030303030303030303030303031303030303030303832304d03",
-    ]
-    for hexmsg in hexmessages:
-        prettyprint(LocationProtocol.from_bytes(bytes.fromhex(hexmsg)))
+class TestLocationProtocl(unittest.TestCase):
 
+    def test_lp(self):
+        hexmessages: List[str] = [
+            # location protocol
+            "a0030034000000000a2338630000413131323534303237303932314e353030332e383734364530313432362e35313932302e32323533ff1cae03",
+            "A0010009200000030A03640E01E503",
+            "a0020032200000030a03640e0000413136323235313331313031384e343733362e363937354530303733392e32363830302e303030358803",
+            "a0010009200000010a03640e01e703",
+            "a0020032200000010a03640e0000413136323232333331313031384e343733362e363937374530303733392e32363830302e303030358903",
+            "a0010009200000020a03640e01e603",
+            # Condition report, no data
+            "d0010039200000020a03640e04000003e830303030303030303030303030303030303030303030303030303030303030303031303030303030303832304d03",
+        ]
+        for hexmsg in hexmessages:
+            print(hexmsg)
+            message = LocationProtocol.from_bytes(bytes.fromhex(hexmsg))
+            prettyprint(message)
+
+    def test_parse_standard_answer(self):
+        hex_location_germany = "a0020032200000010a03640e0000413136323232333331313031384e343733362e363937374530303733392e32363830302e303030358903"
+        message = LocationProtocol.from_bytes(bytes.fromhex(hex_location_germany))
+
+        # Assert properties from LocationProtocol
+        self.assertEqual(message.opcode_header, LocationProtocol.LpSpecificTypes.standard_answer)
+        self.assertEqual(message.opcode, LocationProtocol.LpGeneralTypes.standard_location_immediate_service)
+
+        # Assert properties in Standard Answer
+        self.assertEqual(message.data.result, LocationProtocol.ResultCodes.ok)
+        ## TODO: Test radio id/ip, I think there we can decode directly to the correct id (should be 222222)
+        self.assertEqual(message.data.radio_ip.subnet, 10)
+
+        # Assert properties in gps payload
+        gps_msg = message.data.gpsdata
+        self.assertEqual(gps_msg.gps_status.decode('ascii'), 'A')
+        self.assertEqual(gps_msg.gps_date.decode('ascii'), '311018')
+        self.assertEqual(gps_msg.gps_time.decode('ascii'), '162223')
+        self.assertEqual(gps_msg.east_west.decode('ascii'), 'E')
+        self.assertEqual(gps_msg.longitude.decode('ascii'), '00739.2680')
+        self.assertEqual(gps_msg.north_south.decode('ascii'), 'N')
+        self.assertEqual(gps_msg.latitude.decode('ascii'), '4736.6977')
+        self.assertEqual(gps_msg.direction.decode('ascii'), '005')
+        self.assertEqual(gps_msg.speed.decode('ascii'), '0.0')
+
+        # Payload instances
+        self.assertTrue(gps_msg.gps_available)
 
 if __name__ == "__main__":
-    test_lp()
+    unittest.main()


### PR DESCRIPTION
This is a proposal how we might want to set up unit tests for testing the parsers.

It introduces quite a hard coupling between tests and the kaitai decoding structure.

If this looks fine for you, I might add some more tests like this, especially for the wrapping 
protocols (hdap and hstrp).