### PR TITLE
Fixed type in enum declaration of Hytera DTP

### DIFF
--- a/okdmr/kaitai/hytera/data_transmit_protocol.ksy
+++ b/okdmr/kaitai/hytera/data_transmit_protocol.ksy
@@ -8,7 +8,7 @@ enums:
   service_specific_types:
     0x01: dtp_request
     0x11: dtp_answer
-    0x02: data_slice_trasmit
+    0x02: data_slice_transmit
     0x12: data_slice_answer
     0x03: last_data_slice
     0x13: last_data_slice_answer


### PR DESCRIPTION
While working in java, I found a small typo in the Data Transmit Protocol definition.

It seems like everywhere else, this is referenced correctly.